### PR TITLE
Removes es6 syntax from app.js so that old node version can run build

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,2 +1,2 @@
-import App from './src/index';
-export default new App();
+var App = require('./src/index');
+module.exports = App();

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ const youTubeTimeToSeconds = time => {
   return (mins * 60) + secs;
 };
 
-export default () => {
+module.exports = () => {
   // Extract the url on page load
   const targetEpisode = window.location.pathname.split('/')[2] || 0;
   const targetLanguage = window.location.pathname.split('/')[3] || 'en';


### PR DESCRIPTION
I think this is what was actually causing the error mentioned in asana [here](https://app.asana.com/0/131681076658062/166001106990539). Hopefully this fixes it.

```
# nodejs
> root@d3d13095ecf0:/srv/www# nodejs app.js 

/srv/www/app.js:1
(function (exports, require, module, __filename, __dirname) { import App from 
 ^^^^^^
SyntaxError: Unexpected reserved word
 at Module._compile (module.js:439:25)
 at Object.Module._extensions..js (module.js:474:10)
 at Module.load (module.js:356:32)
 at Function.Module._load (module.js:312:12)
 at Function.Module.runMain (module.js:497:10)
 at startup (node.js:119:16)
 at node.js:902:3
```

An alternative to regressing our code base to the old syntax is to upgrade the containers version of node. There are other advantages such as performance and security that would come along with an upgrade, it can't be that hard, I am going to read up on exactly how to do it tomorrow.
