### PR TITLE
Checks for null time when updating url on tick

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ module.exports = (() => {
 
   // Ensure url times stays synced with player
   subscribe('video:tick', time =>
-    window.history.replaceState({}, '', `?t=${secondsToYoutubeTime(time)}`)
+    time > 0 ? window.history.replaceState({}, '', `?t=${secondsToYoutubeTime(time)}`) : null
   );
 
   const $body = $('body');


### PR DESCRIPTION
Prevents `?t=NaNsNaNmNans` from being set in the url before there is a video tick to calculate time from.