### PR TITLE
Fixes mutliple rendering of chapters in timeline

### DIFF
--- a/src/components/marker-timeline/index.js
+++ b/src/components/marker-timeline/index.js
@@ -38,7 +38,7 @@ export default () => {
   const render = (chapters=[]) => {
     $container.innerHTML = '';
     const duration = chapters.length > 0 ? chapters[chapters.length - 1].end : 0;
-    Fetch(chapters)
+    Fetch([{}])
     .then(Node(() => `
       ${ chapters.map(x =>
         `<chapter- title="${x.title}" start="${x.start}" style="left:${(x.start/duration)*100}%"></chapter->`

--- a/src/components/marker-timeline/style.scss
+++ b/src/components/marker-timeline/style.scss
@@ -33,7 +33,7 @@ marker-timeline {
     height: 100%;
     z-index: 1;
     transform: translateX(-100%);
-    background: rgba(0,0,0,.015);
+    background: rgba(0,0,0,.2);
     &:hover {
       background: rgba(0,0,0,.5);
       &::after {
@@ -51,7 +51,7 @@ marker-timeline {
     &:nth-of-type(1):hover::after,
     &:nth-of-type(2):hover::after,
     &:nth-of-type(3):hover::after {
-      transform: translate(-0%, -125%);
+      transform: translate(0%, -125%);
     }
     &:nth-last-of-type(1):hover::after,
     &:nth-last-of-type(2):hover::after,


### PR DESCRIPTION
In response to chapter titles within the timeline going offscreen, which was an unexpected behavior given that the issue had already been addressed. It was found that markers were being rendered on top of each other multiple times. This has now been fixed, which in turn fixed the chapter label behavior 💥