### PR TITLE
Adds hover labels to experience mode buttons

### DIFF
--- a/src/components/experience-modes/index.js
+++ b/src/components/experience-modes/index.js
@@ -34,15 +34,15 @@ export default () => {
   const $container = document.createElement('experience-modes');
   const render = (state) =>
   Fetch([
-    { icon:'videocam', type:'pr', active:true, state,
+    { label: 'Main Cameras', icon:'videocam', type:'pr', active:true, state,
       hidden: !(state.main && ((state.cameras && state.screens) || state.vr)) },
-    { icon:'featured-video', type:'ms', state,
+    { label: 'Multi Screen', icon:'featured-video', type:'ms', state,
       hidden: !(state.cameras && state.screens) },
-    { icon:'vr', type:'vr', state,
+    { label: '360 Video', icon:'vr', type:'vr', state,
       hidden: !(state.vr) },
   ])
-  .then(Node(({icon,type,active,hidden}) => `
-    <button ${ active ? 'active' : '' } ${ hidden ? 'hidden' : '' }>
+  .then(Node(({label,icon,type,active,hidden}) => `
+    <button data-label='${label}' ${ active ? 'active' : '' } ${ hidden ? 'hidden' : '' }>
       <svg viewBox="0 0 1 1"><use xlink:href="#icon-${icon}"></use></svg>
     </button>
   `))

--- a/src/components/experience-modes/style.scss
+++ b/src/components/experience-modes/style.scss
@@ -20,6 +20,7 @@ experience-modes {
   }
 
   button {
+    position: relative;
     padding: 1rem;
     font-size: .8rem;
     user-select: none;
@@ -30,6 +31,35 @@ experience-modes {
       width: 1rem;
       height: 1rem;
       fill: #fff;
+    }
+
+    &:hover {
+
+      &::after {
+        content: attr(data-label);
+        position: absolute;
+        top: 0;
+        left: 0;
+        background: #212121;
+        display: block;
+        white-space: nowrap;
+        font-size: 1rem;
+        padding: .38rem;
+        transform: translateY(-120%);
+        color: #fff;
+      }
+
+      &::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: .5rem;
+        height: .5rem;
+        background: #212121;
+        transform: rotate(45deg) translateY(-.8rem);
+      }
+
     }
 
     &:not([active]):hover {

--- a/src/components/marker-teleprompter/index.js
+++ b/src/components/marker-teleprompter/index.js
@@ -10,7 +10,7 @@ export default () => {
 
   const setup = (xs) => { data = xs; }
   const render = (time) => {
-    if(time > 0) {
+    if(time > 0 && data.length > 0) {
       const caption = data.find(x => time < x.end) || data[0];
       $container.innerHTML = '';
       Fetch([caption])


### PR DESCRIPTION
As suggested in https://github.com/cs50/video50/pull/97

> Let's add an on-hover to all of the buttons that just very briefly explain what they do, so our viewers will know what they're clicking.

![image](https://cloud.githubusercontent.com/assets/1457604/24596463/a85c55ae-1869-11e7-951d-421a3eaad04b.png)
