### PR TITLE
Widescreen fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "player50",
+  "name": "video50",
   "version": "1.0.0",
   "description": "A web interface for viewing CS50 videos.",
   "main": "index.js",
@@ -19,18 +19,20 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/cs50/player50.git"
+    "url": "https://github.com/cs50/video50.git"
   },
   "author": "Luke Jackson <lukejacksonn@gmail.com> (http://lukejacksonn.com/)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cs50/player50/issues"
+    "url": "https://github.com/cs50/video50/issues"
   },
   "engines": {
     "node": ">=4.5"
   },
   "babel": {
-    "presets": ["es2015"]
+    "presets": [
+      "es2015"
+    ]
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.9.0",
@@ -45,7 +47,7 @@
     "uglifycss": "0.0.20",
     "watchify": "^3.7.0"
   },
-  "homepage": "https://github.com/cs50/player50",
+  "homepage": "https://github.com/cs50/video50",
   "dependencies": {
     "babel-polyfill": "^6.13.0",
     "minpubsub": "git://github.com/lukejacksonn/minpubsub.git",

--- a/src/components/video-alt/index.js
+++ b/src/components/video-alt/index.js
@@ -2,7 +2,7 @@ import YouTubePlayer from 'youtube-player';
 import { subscribe, publish } from 'minpubsub';
 import { draggable, isMobile, isIframe } from '../../helpers/document.js';
 
-export default () => {
+export default (targetEpisode) => {
   const $container = document.querySelector('video-alt');
   const $wrapper = document.createElement('video-');
   const $resize = document.createElement('resize-');
@@ -14,6 +14,19 @@ export default () => {
   // Append wrapper element to be replaced by iframe
   $container.appendChild($wrapper);
   $container.appendChild($resize);
+
+  // Add wide to class so that we know how to properly resize in document helpers
+  // Also start off the component with the right dimensions
+  if (targetEpisode.includes('web') || targetEpisode.includes('mobile') ||
+    targetEpisode.includes('games')) {
+      // Starting width and height for VideoAlt when it instantiates
+      let width = 300;
+      let height = width * 9/16;
+
+      $container.className += ' wide';
+      $container.style.width = `${width}px`;
+      $container.style.height = `${height}px`;
+  }
 
   // Activate dragging if not primary video
   $container.addEventListener('mousedown', (e) => {
@@ -32,9 +45,21 @@ export default () => {
       $container.previousElementSibling.style.left = $container.style.left;
       $container.previousElementSibling.style.top = $container.style.top;
       $container.previousElementSibling.style.width = $container.style.width;
+
+      if ($container.classList.contains('wide')) {
+        $container.previousElementSibling.style.height = $container.style.height;
+      }
+
       $container.style.top = null;
       $container.style.left = null;
-      $container.style.width = null;
+
+      if ($container.classList.contains('wide')) {
+        $container.style.width = '100%';
+        $container.style.height = '100%';
+      } else {
+        $container.style.width = null;
+      }
+      
       $container.previousElementSibling.classList.remove('primary');
       $container.classList.add('primary');
     }

--- a/src/components/video-alt/index.js
+++ b/src/components/video-alt/index.js
@@ -17,8 +17,8 @@ export default (targetEpisode) => {
 
   // Add wide to class so that we know how to properly resize in document helpers
   // Also start off the component with the right dimensions
-  if (targetEpisode.includes('web') || targetEpisode.includes('mobile') ||
-    targetEpisode.includes('games')) {
+  if (targetEpisode.includes('web/2018') || targetEpisode.includes('mobile/2018') ||
+    targetEpisode.includes('games/2018')) {
       // Starting width and height for VideoAlt when it instantiates
       let width = 300;
       let height = width * 9/16;

--- a/src/components/video-main/index.js
+++ b/src/components/video-main/index.js
@@ -16,8 +16,8 @@ export default (targetEpisode) => {
   $container.appendChild($resize);
 
   // Add wide to class so that we know how to properly resize
-  if (targetEpisode.includes('web') || targetEpisode.includes('mobile') ||
-    targetEpisode.includes('games')) {
+  if (targetEpisode.includes('web/2018') || targetEpisode.includes('mobile/2018') ||
+    targetEpisode.includes('games/2018')) {
       $container.className += ' wide';
   }
 

--- a/src/components/video-main/index.js
+++ b/src/components/video-main/index.js
@@ -2,7 +2,7 @@ import YouTubePlayer from 'youtube-player';
 import { subscribe, publish } from 'minpubsub';
 import { draggable, isMobile, isIframe } from '../../helpers/document.js';
 
-export default () => {
+export default (targetEpisode) => {
   const $container = document.querySelector('video-main');
   const $wrapper = document.createElement('video-');
   const $resize = document.createElement('resize-');
@@ -14,6 +14,12 @@ export default () => {
   // Append wrapper element to be replaced by iframe
   $container.appendChild($wrapper);
   $container.appendChild($resize);
+
+  // Add wide to class so that we know how to properly resize
+  if (targetEpisode.includes('web') || targetEpisode.includes('mobile') ||
+    targetEpisode.includes('games')) {
+      $container.className += ' wide';
+  }
 
   // Activate dragging if not primary video
   $container.addEventListener('mousedown', (e) => {
@@ -32,9 +38,21 @@ export default () => {
       $container.nextElementSibling.style.left = $container.style.left;
       $container.nextElementSibling.style.top = $container.style.top;
       $container.nextElementSibling.style.width = $container.style.width;
+
+      if ($container.classList.contains('wide')) {
+        $container.nextElementSibling.style.height = $container.style.height;
+      }
+
       $container.style.top = null;
       $container.style.left = null;
-      $container.style.width = null;
+      
+      if ($container.classList.contains('wide')) {
+        $container.style.width = '100%';
+        $container.style.height = '100%';
+      } else {
+        $container.style.width = null;
+      }
+      
       $container.nextElementSibling.classList.remove('primary');
       $container.classList.add('primary');
     }

--- a/src/helpers/document.js
+++ b/src/helpers/document.js
@@ -99,9 +99,14 @@ export const draggable = function(e) {
     // Set width/height of element according to mouse position
     const size = e.pageX - l + x;
     const min = 150;
+    const pix = size > min ? size : min;
 
     this.style.width = `${size > min ? size : min}px`;
-    //this.style.height = `${(e.pageY - t + y)}px`;
+
+    // if wide flag class is stored, calculate the aspect ratio
+    if (this.className.includes('wide') && !this.className.includes('primary')) {
+      this.style.height = `${Math.floor(pix * 9/16 + 0.5)}px`;
+    }
   }
 
   const unresize = (e) => {

--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,17 @@
       ga('create', 'UA-84629009-1', 'auto');
       ga('send', 'pageview');
     </script>
+    <!-- Hotjar Tracking Code for http://video.cs50.net -->
+    <script>
+        (function(h,o,t,j,a,r){
+            h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+            h._hjSettings={hjid:621897,hjsv:5};
+            a=o.getElementsByTagName('head')[0];
+            r=o.createElement('script');r.async=1;
+            r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+            a.appendChild(r);
+        })(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');
+    </script>
   </head>
   <body breaks="true">
     <div class="wrapper" role="application">

--- a/src/index.js
+++ b/src/index.js
@@ -130,8 +130,8 @@ module.exports = (() => {
 
   documentHelpers();
 
-  VideoMain();
-  VideoAlt();
+  VideoMain(targetEpisode);
+  VideoAlt(targetEpisode);
   VideoExp();
 
   publish('player:loadVideo', [targetEpisode, 'en']);


### PR DESCRIPTION
Temporary solution to allow support for any videos in /mobile, /games, and /web on CDN; avoids parsing JSON for anything by simply string-searching the path. Performs conditional CSS via JavaScript and adds a parameter to the `VideoMain` and `VideoAlt` components so they can read the path and do this.